### PR TITLE
Add option to log requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.15.4",
     "express-ping": "^1.4.0",
     "limiter": "^1.1.2",
+    "logger-request": "^3.8.0",
     "request": "^2.81.0",
     "secure-compare": "^3.0.1",
     "ts-node": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elvis-image-recognition",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "author": {
     "name": "WoodWing - Jaap van Blaaderen",
@@ -32,6 +32,7 @@
     "clarifai": "^2.4.0",
     "console-stamp": "^0.2.5",
     "express": "^4.15.4",
+    "express-ping": "^1.4.0",
     "limiter": "^1.1.2",
     "request": "^2.81.0",
     "secure-compare": "^3.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,12 @@ export class Config {
 
 
   /**
+   * Set access-control-allow-origin header to * instead of elvisUrl. This makes it possible
+   * to configure a non-public or different URL for connecting to Elvis.
+   */
+  static corsOverride: boolean = process.env.CORS_OVERRIDE === 'true' || false;
+
+  /**
    * Recognize images right after they are imported in Elvis.
    * 
    * This depends on webhooks, make sure to also configure the elvisToken correctly when this setting is enabled.

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,16 @@ export class Config {
   static httpsPort: string = process.env.IR_HTTPS_PORT || '9443';
 
   /**
+   * Enable status check on /ping.
+   */
+  static pingEnabled: boolean = process.env.IR_PING_ENABLED === 'true' || false;
+
+  /**
+   * Set status check endpoint. Default is /ping.
+   */
+  static pingEndpoint: string = process.env.IR_PING_ENDPOINT || 'ping';
+
+  /**
    * SSL private key.
    */
   static httpsKeyFile: string = process.env.IR_HTTPS_KEY_FILE || './https/server.key';

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,21 @@ export class Config {
   static tempDir: string = process.env.IR_TEMP_DIR || './temp';
 
   /**
+   * Log requests [true/false].
+   */
+  static logRequests: boolean = process.env.IR_LOG_REQUESTS === 'true' || false;
+
+  /**
+   * File to store request logs in.
+   */
+  static logFile: string = process.env.IR_LOG_FILE || 'requests.log';
+
+  /**
+   * Maximum number of log files to keep.
+   */
+  static logMaxFiles: string = process.env.IR_LOG_MAX_FILES || '31';
+
+  /**
    * Elvis server url.
    */
   static elvisUrl: string = process.env.IR_ELVIS_URL || 'http://localhost:8080';

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@
 
 require("console-stamp")(console, { pattern: "dd-mm-yyyy HH:MM:ss.l" });
 import express = require('express');
+import health = require('express-ping');
 import http = require('http');
 import https = require('https');
 import fs = require('fs');
@@ -38,6 +39,9 @@ class Server {
       this.httpsApp = express();
     }
     this.app = Config.httpsEnabled ? this.httpsApp : this.httpApp;
+    if (Config.pingEnabled) {
+        this.app.use(health.ping('/' + Config.pingEndpoint));
+    }
     if (Config.recognizeOnImport) {
       this.webhookEndPoint = new WebhookEndpoint(this.app);
     }
@@ -97,6 +101,9 @@ class Server {
     console.info(serverMsg);
     console.info('Recognize imported files on import: ' + Config.recognizeOnImport);
     console.info('REST API enabled: ' + Config.restAPIEnabled);
+    if (Config.pingEnabled) {
+      console.info('Ping endpoint enabled at: /' + Config.pingEndpoint);
+    }
   }
 
   private allowCrossDomain = function (req, res, next) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import express = require('express');
 import health = require('express-ping');
 import http = require('http');
 import https = require('https');
+import logger = require('logger-request');
 import fs = require('fs');
 import { Application } from 'express';
 import bodyParser = require('body-parser');
@@ -41,6 +42,20 @@ class Server {
     this.app = Config.httpsEnabled ? this.httpsApp : this.httpApp;
     if (Config.pingEnabled) {
         this.app.use(health.ping('/' + Config.pingEndpoint));
+    }
+    if (Config.logRequests) {
+      this.app.use(logger({
+        filename: Config.logFile,
+        maxFiles: Config.logMaxFiles,
+        console: false,
+        custom: {
+          bytesReq: true,
+          bytesRes: true,
+          transfer: true,
+          referer: true,
+          agent: true
+        }
+      }));
     }
     if (Config.recognizeOnImport) {
       this.webhookEndPoint = new WebhookEndpoint(this.app);
@@ -103,6 +118,9 @@ class Server {
     console.info('REST API enabled: ' + Config.restAPIEnabled);
     if (Config.pingEnabled) {
       console.info('Ping endpoint enabled at: /' + Config.pingEndpoint);
+    }
+    if (Config.pingEnabled) {
+      console.info('Requests are logged at: ' + Config.logFile);
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -128,7 +128,7 @@ class Server {
     // Keep the compiler happy
     req = req;
 
-    res.header('Access-Control-Allow-Origin', Config.elvisUrl);
+    res.header('Access-Control-Allow-Origin', Config.corsOverride ? '*': Config.elvisUrl);
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
     res.header('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-Type,Accept');
 


### PR DESCRIPTION
Logging is disabled by default. When logging is enabled, log files will be
rotated daily.

Settings added:
* logRequests: boolean: Whether requests should be logged. Default: false.
* logFile: string: File to log requests to. Default: requests.log.
* logMaxFiles: integrer: Number of log files to keep. Default: 31.

Library used: https://www.npmjs.com/package/logger-request