### PR TITLE
Allow overriding Cross-Origin Resource Sharing header

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,12 @@ export class Config {
 
 
   /**
+   * Set access-control-allow-origin header to * instead of elvisUrl. This makes it possible
+   * to configure a non-public or different URL for connecting to Elvis.
+   */
+  static corsOverride: boolean = process.env.CORS_OVERRIDE === 'true' || false;
+
+  /**
    * Recognize images right after they are imported in Elvis.
    * 
    * This depends on webhooks, make sure to also configure the elvisToken correctly when this setting is enabled.

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,7 +103,7 @@ class Server {
     // Keep the compiler happy
     req = req;
 
-    res.header('Access-Control-Allow-Origin', Config.elvisUrl);
+    res.header('Access-Control-Allow-Origin', Config.corsOverride ? '*': Config.elvisUrl);
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
     res.header('Access-Control-Allow-Headers', 'Origin,X-Requested-With,Content-Type,Accept');
 


### PR DESCRIPTION
This makes it possible to use a different URL for connecting to the API
and still allowing connections to the image recognition server from the
pro client.

Ideally I'd have made this configurable, but I couldn't find a way to do
that. res.header 'Access-Control-Allow-Origin' doesn't allow setting
multiple domains in it.

This fixes https://github.com/WoodWing/elvis-image-recognition/issues/5