### PR TITLE
Add a simple health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   * [8.2 Recognize existing images in Elvis with the Auto Tag Images plug-in](#82-recognize-existing-images-in-elvis-with-the-auto-tag-images-plug-in)
 - [9. Privacy and data usage](#9-privacy-and-data-usage)
 - [10. Version history](#10-version-history)
+  * [v2.2.0](#v220)
   * [v2.1.0](#v210)
   * [v2.0.0](#v200)
   * [v1.1.0](#v110)
@@ -259,6 +260,12 @@ As explained in the architecture overview, the image recognition server sends pr
 - [Google Cloud Vision Data Usage](https://cloud.google.com/vision/docs/data-usage)
 
 # 10. Version history
+
+## v2.2.0
+
+This version has not yet been released.
+
+- Health check endpoint is now available at /ping. If the service is available, the response will be a JSON payload of ```{ "uptime": [uptime in seconds] }``` and a 200 status code.
 
 ## v2.1.0
 - Google Vision: Implement OCR, logo detection, web entities and web links. 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clarifai": "^2.4.0",
     "console-stamp": "^0.2.5",
     "express": "^4.15.4",
+    "express-healthcheck": "^0.1.0",
     "limiter": "^1.1.2",
     "request": "^2.81.0",
     "secure-compare": "^3.0.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ class Server {
       this.httpsApp = express();
     }
     this.app = Config.httpsEnabled ? this.httpsApp : this.httpApp;
+    this.app.use('/ping', require('express-healthcheck')());
     if (Config.recognizeOnImport) {
       this.webhookEndPoint = new WebhookEndpoint(this.app);
     }


### PR DESCRIPTION
This adds a simple health check at /ping.

Example:

$ curl localhost:9090/ping
{"uptime":178.496}