### PR TITLE
Add option to log requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   * [8.2 Recognize existing images in Elvis with the Auto Tag Images plug-in](#82-recognize-existing-images-in-elvis-with-the-auto-tag-images-plug-in)
 - [9. Privacy and data usage](#9-privacy-and-data-usage)
 - [10. Version history](#10-version-history)
+  * [v2.2.0](#v220)
   * [v2.1.0](#v210)
   * [v2.0.0](#v200)
   * [v1.1.0](#v110)
@@ -259,6 +260,12 @@ As explained in the architecture overview, the image recognition server sends pr
 - [Google Cloud Vision Data Usage](https://cloud.google.com/vision/docs/data-usage)
 
 # 10. Version history
+
+## v2.2.0
+
+This version has not yet been released.
+
+-  Add configuration options for request logging: logRequests, logFile, logMaxFiles. See config.ts for details.
 
 ## v2.1.0
 - Google Vision: Implement OCR, logo detection, web entities and web links. 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "console-stamp": "^0.2.5",
     "express": "^4.15.4",
     "limiter": "^1.1.2",
+    "logger-request": "^3.8.0",
     "request": "^2.81.0",
     "secure-compare": "^3.0.1",
     "ts-node": "^3.3.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,21 @@ export class Config {
   static tempDir: string = process.env.IR_TEMP_DIR || './temp';
 
   /**
+   * Log requests [true/false].
+   */
+  static logRequests: boolean = process.env.IR_LOG_REQUESTS === 'true' || false;
+
+  /**
+   * File to store request logs in.
+   */
+  static logFile: string = process.env.IR_LOG_FILE || 'requests.log';
+
+  /**
+   * Maximum number of log files to keep.
+   */
+  static logMaxFiles: string = process.env.IR_LOG_MAX_FILES || '31';
+
+  /**
    * Elvis server url.
    */
   static elvisUrl: string = process.env.IR_ELVIS_URL || 'http://localhost:8080';

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ require("console-stamp")(console, { pattern: "dd-mm-yyyy HH:MM:ss.l" });
 import express = require('express');
 import http = require('http');
 import https = require('https');
+import logger = require('logger-request');
 import fs = require('fs');
 import { Application } from 'express';
 import bodyParser = require('body-parser');
@@ -38,6 +39,21 @@ class Server {
       this.httpsApp = express();
     }
     this.app = Config.httpsEnabled ? this.httpsApp : this.httpApp;
+    if (Config.logRequests) {
+      this.app.use(logger({
+        filename: Config.logFile,
+	daily: true,
+        maxFiles: Config.logMaxFiles,
+        console: false,
+        custom: {
+          bytesReq: true,
+          bytesRes: true,
+          transfer: true,
+          referer: true,
+          agent: true
+        }
+      }));
+    }
     if (Config.recognizeOnImport) {
       this.webhookEndPoint = new WebhookEndpoint(this.app);
     }


### PR DESCRIPTION
Logging is disabled by default. When logging is enabled, log files will be
rotated daily.

Settings added:
* logRequests: boolean: Whether requests should be logged. Default: false.
* logFile: string: File to log requests to. Default: requests.log.
* logMaxFiles: integrer: Number of log files to keep. Default: 31.

Library used: https://www.npmjs.com/package/logger-request